### PR TITLE
fix cloud-config user NOPASSWD

### DIFF
--- a/firezone/templates/cloud-init_firezone.tpl.yaml
+++ b/firezone/templates/cloud-init_firezone.tpl.yaml
@@ -2,7 +2,7 @@
 
 users:
   - name: ${firezone_vm_username}
-    sudo: ALL=(ALL) NOPASSWD:ALL
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
     shell: /bin/bash
     ssh-authorized-keys:
       - "${firezone_ssh_key_pub}"

--- a/keycloak-deploy/templates/kc-vm-init.tpl
+++ b/keycloak-deploy/templates/kc-vm-init.tpl
@@ -6,7 +6,7 @@ datasource:
 ssh_pwauth: yes
 users:
   - name: "${ADMIN_NAME}"
-    sudo: ALL=(ALL) NOPASSWD:ALL
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
     shell: /bin/bash
     ssh-authorized-keys:
       - "${ADMIN_SSH_KEY}"


### PR DESCRIPTION
Строку `ALL=(ALL) NOPASSWD:ALL` в cloud config требуется указывать в кавычках (`"ALL=(ALL) NOPASSWD:ALL"`), чтобы избежать неправильного парсинга конфига cloud-init.
Без кавычек данное правило не применяется